### PR TITLE
Fix error handling and logging in the serializer

### DIFF
--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -23,8 +23,7 @@ class SqlSerializer {
     void serialize_promise_origin(prom_id_t id, bool default_argument);
     void serialize_force_promise_entry(dyntrace_context_t *context,
                                        const prom_info_t &info, int clock_id);
-    void serialize_force_promise_exit(const prom_info_t &info,
-                                      int clock_id);
+    void serialize_force_promise_exit(const prom_info_t &info, int clock_id);
     void serialize_promise_created(const prom_basic_info_t &info);
     void serialize_promise_lookup(const prom_info_t &info, int clock_id);
     void serialize_promise_expression_lookup(const prom_info_t &info,
@@ -41,7 +40,8 @@ class SqlSerializer {
                             env_id_t environment_id);
     void serialize_variable_action(prom_id_t promise_id, var_id_t variable_id,
                                    const std::string &action);
-    void serialize_interference_information(const std::string& information);
+    void serialize_interference_information(const std::string &information);
+
   private:
     sqlite3_stmt *compile(const char *statement);
     void execute(sqlite3_stmt *statement);
@@ -52,6 +52,7 @@ class SqlSerializer {
     void create_tables(const std::string schema_path);
     void prepare_statements();
     void finalize_statements();
+    void cleanup();
     void unindent();
     void indent();
 
@@ -74,25 +75,26 @@ class SqlSerializer {
 
     sqlite3_stmt *populate_insert_argument_statement(const closure_info_t &info,
                                                      int index);
+
     bool verbose;
     int indentation;
-    sqlite3 *database = nullptr;
+    sqlite3 *database = NULL;
     std::ofstream trace;
-    sqlite3_stmt *insert_metadata_statement = nullptr;
-    sqlite3_stmt *insert_function_statement = nullptr;
-    sqlite3_stmt *insert_argument_statement = nullptr;
-    sqlite3_stmt *insert_call_statement = nullptr;
-    sqlite3_stmt *insert_promise_statement = nullptr;
-    sqlite3_stmt *insert_promise_association_statement = nullptr;
-    sqlite3_stmt *insert_promise_evaluation_statement = nullptr;
-    sqlite3_stmt *insert_promise_return_statement = nullptr;
-    sqlite3_stmt *insert_promise_lifecycle_statement = nullptr;
-    sqlite3_stmt *insert_promise_argument_type_statement = nullptr;
-    sqlite3_stmt *insert_gc_trigger_statement = nullptr;
-    sqlite3_stmt *insert_type_distribution_statement = nullptr;
-    sqlite3_stmt *insert_environment_statement = nullptr;
-    sqlite3_stmt *insert_variable_statement = nullptr;
-    sqlite3_stmt *insert_variable_action_statement = nullptr;
+    sqlite3_stmt *insert_metadata_statement = NULL;
+    sqlite3_stmt *insert_function_statement = NULL;
+    sqlite3_stmt *insert_argument_statement = NULL;
+    sqlite3_stmt *insert_call_statement = NULL;
+    sqlite3_stmt *insert_promise_statement = NULL;
+    sqlite3_stmt *insert_promise_association_statement = NULL;
+    sqlite3_stmt *insert_promise_evaluation_statement = NULL;
+    sqlite3_stmt *insert_promise_return_statement = NULL;
+    sqlite3_stmt *insert_promise_lifecycle_statement = NULL;
+    sqlite3_stmt *insert_promise_argument_type_statement = NULL;
+    sqlite3_stmt *insert_gc_trigger_statement = NULL;
+    sqlite3_stmt *insert_type_distribution_statement = NULL;
+    sqlite3_stmt *insert_environment_statement = NULL;
+    sqlite3_stmt *insert_variable_statement = NULL;
+    sqlite3_stmt *insert_variable_action_statement = NULL;
 };
 
 #endif /* __SQL_SERIALIZER_H__ */

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -101,21 +101,22 @@ void serialize_execution_time(dyntrace_context_t *context) {
 
 void end(dyntrace_context_t *context) {
     tracer_state(context).finish_pass();
-    serialize_execution_time(context);
-    // serialize_execution_count(context);
-    tracer_serializer(context).serialize_finish_trace();
-    tracer_serializer(context).serialize_metadatum(
-        "DYNTRACE_END_DATETIME",
-        remove_null(context->dyntracing_context->end_datetime));
+        serialize_execution_time(context);
+        // serialize_execution_count(context);
+        tracer_serializer(context).serialize_finish_trace();
+        tracer_serializer(context).serialize_metadatum(
+            "DYNTRACE_END_DATETIME",
+            remove_null(context->dyntracing_context->end_datetime));
+
     if (!tracer_state(context).fun_stack.empty()) {
-        Rprintf("Function stack is not balanced: %d remaining.\n",
-                tracer_state(context).fun_stack.size());
+        dyntrace_log_warning("Function stack is not balanced: %d remaining",
+                             tracer_state(context).fun_stack.size());
         tracer_state(context).fun_stack.clear();
     }
 
     if (!tracer_state(context).full_stack.empty()) {
-        Rprintf("Function/promise stack is not balanced: %d remaining.\n",
-                tracer_state(context).full_stack.size());
+        dyntrace_log_warning("Function/promise stack is not balanced: %d remaining",
+                             tracer_state(context).full_stack.size());
         tracer_state(context).full_stack.clear();
     }
 }

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -15,43 +15,38 @@
 extern "C" {
 
 SEXP create_dyntracer(SEXP database, SEXP schema, SEXP truncate, SEXP verbose) {
-    try {
-        void *context =
-            new Context(sexp_to_string(database), sexp_to_string(schema),
-                        sexp_to_bool(truncate), sexp_to_bool(verbose));
-        /* calloc initializes the memory to zero. This ensures that probes not
-           attached will be NULL. Replacing calloc with malloc will cause
-           segfaults. */
-        dyntracer_t *dyntracer = (dyntracer_t *)calloc(1, sizeof(dyntracer_t));
-        dyntracer->probe_begin = begin;
-        dyntracer->probe_end = end;
-        dyntracer->probe_function_entry = function_entry;
-        dyntracer->probe_function_exit = function_exit;
-        dyntracer->probe_builtin_entry = builtin_entry;
-        dyntracer->probe_builtin_exit = builtin_exit;
-        dyntracer->probe_specialsxp_entry = specialsxp_entry;
-        dyntracer->probe_specialsxp_exit = specialsxp_exit;
-        dyntracer->probe_gc_promise_unmarked = gc_promise_unmarked;
-        dyntracer->probe_promise_force_entry = promise_force_entry;
-        dyntracer->probe_promise_force_exit = promise_force_exit;
-        dyntracer->probe_promise_created = promise_created;
-        dyntracer->probe_promise_value_lookup = promise_value_lookup;
-        dyntracer->probe_promise_expression_lookup = promise_expression_lookup;
-        dyntracer->probe_vector_alloc = vector_alloc;
-        dyntracer->probe_gc_entry = gc_entry;
-        dyntracer->probe_gc_exit = gc_exit;
-        dyntracer->probe_new_environment = new_environment;
-        dyntracer->probe_jump_ctxt = jump_ctxt;
-        dyntracer->probe_environment_define_var = environment_define_var;
-        dyntracer->probe_environment_assign_var = environment_assign_var;
-        dyntracer->probe_environment_remove_var = environment_remove_var;
-        dyntracer->probe_environment_lookup_var = environment_lookup_var;
-        dyntracer->context = context;
-        return dyntracer_to_sexp(dyntracer, "dyntracer.promise");
-    } catch (const std::runtime_error &e) {
-        Rf_error(e.what());
-        return R_NilValue;
-    }
+    void *context =
+        new Context(sexp_to_string(database), sexp_to_string(schema),
+                    sexp_to_bool(truncate), sexp_to_bool(verbose));
+    /* calloc initializes the memory to zero. This ensures that probes not
+       attached will be NULL. Replacing calloc with malloc will cause
+       segfaults. */
+    dyntracer_t *dyntracer = (dyntracer_t *)calloc(1, sizeof(dyntracer_t));
+    dyntracer->probe_begin = begin;
+    dyntracer->probe_end = end;
+    dyntracer->probe_function_entry = function_entry;
+    dyntracer->probe_function_exit = function_exit;
+    dyntracer->probe_builtin_entry = builtin_entry;
+    dyntracer->probe_builtin_exit = builtin_exit;
+    dyntracer->probe_specialsxp_entry = specialsxp_entry;
+    dyntracer->probe_specialsxp_exit = specialsxp_exit;
+    dyntracer->probe_gc_promise_unmarked = gc_promise_unmarked;
+    dyntracer->probe_promise_force_entry = promise_force_entry;
+    dyntracer->probe_promise_force_exit = promise_force_exit;
+    dyntracer->probe_promise_created = promise_created;
+    dyntracer->probe_promise_value_lookup = promise_value_lookup;
+    dyntracer->probe_promise_expression_lookup = promise_expression_lookup;
+    dyntracer->probe_vector_alloc = vector_alloc;
+    dyntracer->probe_gc_entry = gc_entry;
+    dyntracer->probe_gc_exit = gc_exit;
+    dyntracer->probe_new_environment = new_environment;
+    dyntracer->probe_jump_ctxt = jump_ctxt;
+    dyntracer->probe_environment_define_var = environment_define_var;
+    dyntracer->probe_environment_assign_var = environment_assign_var;
+    dyntracer->probe_environment_remove_var = environment_remove_var;
+    dyntracer->probe_environment_lookup_var = environment_lookup_var;
+    dyntracer->context = context;
+    return dyntracer_to_sexp(dyntracer, "dyntracer.promise");
 }
 
 static void destroy_promise_dyntracer(dyntracer_t *dyntracer) {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,6 +1,9 @@
 #include "utilities.h"
 #include "base64.h"
 
+size_t SQLITE3_ERROR_MESSAGE_BUFFER_SIZE = 1000;
+size_t SQLITE3_EXPANDED_SQL_BUFFER_SIZE = 2000;
+
 int get_file_size(std::ifstream &file) {
     int position = file.tellg();
     file.seekg(0, std::ios_base::end);
@@ -9,13 +12,7 @@ int get_file_size(std::ifstream &file) {
     return length;
 }
 
-std::string readfile(const std::string &filepath) {
-
-    std::ifstream file(filepath);
-    if (!file.good()) {
-        throw std::runtime_error(std::string("unable to open file: ") +
-                                 filepath);
-    }
+std::string readfile(std::ifstream &file) {
     std::string contents;
     file.seekg(0, std::ios::end);
     contents.reserve(file.tellg());
@@ -27,6 +24,17 @@ std::string readfile(const std::string &filepath) {
 
 bool file_exists(const std::string &filepath) {
     return std::ifstream(filepath).good();
+}
+
+char *copy_string(char *destination, const char *source, size_t buffer_size) {
+    size_t l = strlen(source);
+    if (l >= buffer_size) {
+        strncpy(destination, source, buffer_size - 1);
+        destination[buffer_size - 1] = '\0';
+    } else {
+        strcpy(destination, source);
+    }
+    return destination;
 }
 
 bool sexp_to_bool(SEXP value) { return LOGICAL(value)[0] == TRUE; }
@@ -217,7 +225,8 @@ std::string compute_hash(const char *data) {
     EVP_DigestFinal_ex(mdctx, md_value, &md_len);
     EVP_MD_CTX_free(mdctx);
 
-    return base64_encode(reinterpret_cast<const unsigned char *>(md_value), md_len);
+    return base64_encode(reinterpret_cast<const unsigned char *>(md_value),
+                         md_len);
 }
 
 const char *remove_null(const char *value) { return value ? value : ""; }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -4,11 +4,16 @@
 #include "stdlibs.h"
 #include <openssl/evp.h>
 
+extern size_t SQLITE3_ERROR_MESSAGE_BUFFER_SIZE;
+extern size_t SQLITE3_EXPANDED_SQL_BUFFER_SIZE;
+
 int get_file_size(std::ifstream &file);
 
-std::string readfile(const std::string &filepath);
+std::string readfile(std::ifstream &file);
 
 bool file_exists(const std::string &filepath);
+
+char * copy_string(char * destination, const char * source, size_t buffer_size);
 
 bool sexp_to_bool(SEXP value);
 


### PR DESCRIPTION
This commit replaces all warning and error reporting calls
with their `dyntrace` equivalents.

Error handling has been significantly improved, many new
cases have been handled.

Resolves #3