### PR TITLE
Fixed errors with variable lookup.

### DIFF
--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -460,10 +460,10 @@ sqlite3_stmt *SqlSerializer::populate_call_statement(const call_info_t &info) {
         sqlite3_bind_text(insert_call_statement, 2, info.name.c_str(), -1,
                           SQLITE_TRANSIENT);
 
-    if (info.callsite.empty())
+    if (info.callsite_location.empty())
         sqlite3_bind_null(insert_call_statement, 3);
     else
-        sqlite3_bind_text(insert_call_statement, 3, info.callsite.c_str(), -1,
+        sqlite3_bind_text(insert_call_statement, 3, info.callsite_location.c_str(), -1,
                           SQLITE_TRANSIENT);
 
     sqlite3_bind_int(insert_call_statement, 4, info.fn_compiled ? 1 : 0);
@@ -530,10 +530,10 @@ SqlSerializer::populate_function_statement(const call_info_t &info) {
     sqlite3_bind_text(insert_function_statement, 1, info.fn_id.c_str(),
                       info.fn_id.length(), NULL);
 
-    if (info.loc.empty())
+    if (info.definition_location.empty())
         sqlite3_bind_null(insert_function_statement, 2);
     else
-        sqlite3_bind_text(insert_function_statement, 2, info.loc.c_str(), -1,
+        sqlite3_bind_text(insert_function_statement, 2, info.definition_location.c_str(), -1,
                           SQLITE_TRANSIENT);
 
     if (info.fn_definition.empty())

--- a/src/State.h
+++ b/src/State.h
@@ -93,8 +93,8 @@ struct call_info_t {
     fn_id_t fn_id;
     fn_addr_t fn_addr; // TODO unnecessary?
     string fn_definition;
-    string loc;
-    string callsite;
+    string definition_location;
+    string callsite_location;
     bool fn_compiled;
 
     string name; // fully qualified function name, if available
@@ -104,7 +104,7 @@ struct call_info_t {
         parent_call_id; // the id of the parent call that executed this call
     prom_id_t in_prom_id;
 
-    recursion_type recursion;
+    recursion_type recursion; // TODO unnecessary?
 
     stack_event_t parent_on_stack;
 };

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -1,19 +1,15 @@
 #include "lookup.h"
 
 lookup_result find_binding_in_global_cache(const SEXP symbol) {
-    //dyntrace_log_error(
-    //    "my_find_in_global_cache, missing implementation, confused");
     return {lookup_status::FAIL_GLOBAL_CACHE, R_UnboundValue};
 }
 
 /*inline*/ lookup_result get_symbol_binding_value(const SEXP symbol) {
     if (IS_ACTIVE_BINDING(symbol)) {
-        //SEXP expr = LCONS(SYMVALUE(symbol), R_NilValue);
         SEXP expr = SYMVALUE(symbol);
         return {lookup_status::SUCCESS_ACTIVE_BINDING, expr};
     }
     return {lookup_status::SUCCESS, SYMVALUE(symbol)};
-    // Removed: if IS_ACTIVE_BINDING(s) ? getActiveValue(SYMVALUE(s))
 }
 
 /*inline*/ lookup_result get_binding_value(const SEXP frame) {
@@ -22,7 +18,6 @@ lookup_result find_binding_in_global_cache(const SEXP symbol) {
         return {lookup_status::SUCCESS_ACTIVE_BINDING, expr};
     }
     return {lookup_status::SUCCESS, CAR(frame)};
-    // Removed: if IS_ACTIVE_BINDING(s) ? getActiveValue(CAR(s))
 }
 
 /*inline*/ lookup_result get_hash(int hashcode, SEXP symbol, SEXP table) {
@@ -44,7 +39,7 @@ lookup_result find_binding_in_single_environment(const SEXP symbol, const SEXP r
     if (rho == R_EmptyEnv)
         return {lookup_status::SUCCESS, R_UnboundValue};
 
-    if ((OBJECT(rho)) && inherits((rho), "UserDefinedDatabase")) // IS_USER_DATABASE(rho)
+    if ((OBJECT(rho)) && inherits((rho), "UserDefinedDatabase"))
         return {lookup_status::FAIL_USER_DEFINED_DATABASE, R_UnboundValue};
 
     if (HASHTAB(rho) == R_NilValue) {
@@ -80,11 +75,10 @@ lookup_result find_binding_in_environment(const SEXP symbol, const SEXP rho2) {
         return {lookup_status::FAIL_ARGUMENT_IS_NOT_AN_ENVIRONMENT, R_UnboundValue};
 
 #ifdef USE_GLOBAL_CACHE
-    while (rho != R_GlobalEnv && rho != R_EmptyEnv)
+    while (rho != R_GlobalEnv && rho != R_EmptyEnv) {
 #else
-    while (rho != R_EmptyEnv)
+    while (rho != R_EmptyEnv) {
 #endif
-    {
         lookup_result r = find_binding_in_single_environment(symbol, rho);
 
         if (r.status != lookup_status::SUCCESS)

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -1,49 +1,51 @@
 #include "lookup.h"
 
-SEXP find_promise_in_global_cache(const SEXP symbol) {
-    dyntrace_log_error(
-        "my_find_in_global_cache, missing implementation, confused");
+lookup_result find_binding_in_global_cache(const SEXP symbol) {
+    //dyntrace_log_error(
+    //    "my_find_in_global_cache, missing implementation, confused");
+    return {lookup_status::FAIL_GLOBAL_CACHE, R_UnboundValue};
 }
 
-inline SEXP get_symbol_binding_value(const SEXP symbol) {
-    if (IS_ACTIVE_BINDING(symbol))
-        dyntrace_log_error("encountered ACTIVE BINDING symbol, missing "
-                           "implementation, confused");
-    return SYMVALUE(symbol); // Removed: if IS_ACTIVE_BINDING(s) ?
-                             // getActiveValue(SYMVALUE(s))
+/*inline*/ lookup_result get_symbol_binding_value(const SEXP symbol) {
+    if (IS_ACTIVE_BINDING(symbol)) {
+        //SEXP expr = LCONS(SYMVALUE(symbol), R_NilValue);
+        SEXP expr = SYMVALUE(symbol);
+        return {lookup_status::SUCCESS_ACTIVE_BINDING, expr};
+    }
+    return {lookup_status::SUCCESS, SYMVALUE(symbol)};
+    // Removed: if IS_ACTIVE_BINDING(s) ? getActiveValue(SYMVALUE(s))
 }
 
-inline SEXP get_binding_value(const SEXP frame) {
-    if (IS_ACTIVE_BINDING(frame))
-        dyntrace_log_error("encountered ACTIVE BINDING frame, missing "
-                           "implementation, confused");
-    return CAR(
-        frame); // Removed: if IS_ACTIVE_BINDING(s) ? getActiveValue(CAR(s))
+/*inline*/ lookup_result get_binding_value(const SEXP frame) {
+    if (IS_ACTIVE_BINDING(frame)) {
+        SEXP expr = CAR(frame);
+        return {lookup_status::SUCCESS_ACTIVE_BINDING, expr};
+    }
+    return {lookup_status::SUCCESS, CAR(frame)};
+    // Removed: if IS_ACTIVE_BINDING(s) ? getActiveValue(CAR(s))
 }
 
-inline SEXP get_hash(int hashcode, SEXP symbol, SEXP table) {
+/*inline*/ lookup_result get_hash(int hashcode, SEXP symbol, SEXP table) {
     for (SEXP chain = VECTOR_ELT(table, hashcode); chain != R_NilValue;
          chain = CDR(chain)) {
         if (TAG(chain) == symbol)
             return get_binding_value(chain);
     }
-    return R_UnboundValue;
+    return {lookup_status::SUCCESS, R_UnboundValue};
 }
 
-SEXP find_promise_in_single_environment(const SEXP symbol, const SEXP rho) {
+lookup_result find_binding_in_single_environment(const SEXP symbol, const SEXP rho) {
     if (TYPEOF(rho) == NILSXP)
-        dyntrace_log_error("encountered NILSXP as environment");
+        return {lookup_status::FAIL_ENVIRONMENT_IS_NIL, R_UnboundValue};
 
     if (rho == R_BaseNamespace || rho == R_BaseEnv)
         return get_symbol_binding_value(symbol);
 
     if (rho == R_EmptyEnv)
-        return R_UnboundValue;
+        return {lookup_status::SUCCESS, R_UnboundValue};
 
-    if ((OBJECT(rho)) &&
-        inherits((rho), "UserDefinedDatabase")) // (IS_USER_DATABASE(rho))
-        dyntrace_log_error("encountered UserDefinedDatabase class environment, "
-                           "missing implementation, confused");
+    if ((OBJECT(rho)) && inherits((rho), "UserDefinedDatabase")) // IS_USER_DATABASE(rho)
+        return {lookup_status::FAIL_USER_DEFINED_DATABASE, R_UnboundValue};
 
     if (HASHTAB(rho) == R_NilValue) {
         SEXP frame = FRAME(rho);
@@ -65,17 +67,17 @@ SEXP find_promise_in_single_environment(const SEXP symbol, const SEXP rho) {
         return get_hash(hashcode, symbol, HASHTAB(rho));
     }
 
-    return R_UnboundValue;
+    return {lookup_status::SUCCESS, R_UnboundValue};
 }
 
-SEXP find_promise_in_environment(const SEXP symbol, const SEXP rho2) {
+lookup_result find_binding_in_environment(const SEXP symbol, const SEXP rho2) {
     SEXP rho = rho2;
 
     if (TYPEOF(rho) == NILSXP)
-        dyntrace_log_error("encountered NILSXP as environment");
+        return {lookup_status::FAIL_ENVIRONMENT_IS_NIL, R_UnboundValue};
 
     if (TYPEOF(rho) != ENVSXP)
-        dyntrace_log_error("second argument is not an environment");
+        return {lookup_status::FAIL_ARGUMENT_IS_NOT_AN_ENVIRONMENT, R_UnboundValue};
 
 #ifdef USE_GLOBAL_CACHE
     while (rho != R_GlobalEnv && rho != R_EmptyEnv)
@@ -83,9 +85,14 @@ SEXP find_promise_in_environment(const SEXP symbol, const SEXP rho2) {
     while (rho != R_EmptyEnv)
 #endif
     {
-        SEXP v = find_promise_in_single_environment(symbol, rho);
-        if (v != R_UnboundValue)
-            return v;
+        lookup_result r = find_binding_in_single_environment(symbol, rho);
+
+        if (r.status != lookup_status::SUCCESS)
+            return r;
+
+        if (r.value != R_UnboundValue)
+            return r;
+
         rho = ENCLOS(rho);
     }
 #ifdef USE_GLOBAL_CACHE
@@ -93,5 +100,18 @@ SEXP find_promise_in_environment(const SEXP symbol, const SEXP rho2) {
         return find_promise_in_global_cache(symbol);
     else
 #endif
-        return R_UnboundValue;
+        return {lookup_status::SUCCESS, R_UnboundValue};
+}
+
+string lookup_status_to_string(lookup_status status) {
+    switch (status) {
+        case lookup_status::FAIL_ARGUMENT_IS_NOT_AN_ENVIRONMENT:
+            return "Lookup in environment failed: second argument is not an environment";
+        case lookup_status::FAIL_ENVIRONMENT_IS_NIL:
+            return "Lookup in environment failed: NIL is not a valid environment (anymore)";
+        case lookup_status::FAIL_GLOBAL_CACHE:
+            return "Lookup in environment failed: global cache";
+        case lookup_status::FAIL_USER_DEFINED_DATABASE:
+            return "Lookup in environment failed: user defined database";
+    }
 }

--- a/src/lookup.h
+++ b/src/lookup.h
@@ -5,6 +5,22 @@
 
 using namespace std;
 
-SEXP find_promise_in_environment(const SEXP symbol, const SEXP rho2);
+enum class lookup_status {
+    SUCCESS,
+    SUCCESS_ACTIVE_BINDING,
+    FAIL_USER_DEFINED_DATABASE,
+    FAIL_ENVIRONMENT_IS_NIL,
+    FAIL_ARGUMENT_IS_NOT_AN_ENVIRONMENT,
+    FAIL_GLOBAL_CACHE
+};
+
+std::string lookup_status_to_string(lookup_status);
+
+struct lookup_result {
+    lookup_status status;
+    SEXP value;
+};
+
+lookup_result find_binding_in_environment(const SEXP symbol, const SEXP environment);
 
 #endif /* __LOOKUP_H__ */

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -110,16 +110,8 @@ closure_info_t function_entry_get_info(dyntrace_context_t *context,
 
     call_stack_elem_t elem = (tracer_state(context).fun_stack.back());
     info.parent_call_id = get<0>(elem);
-
-    char *location = get_location(op);
-    if (location != NULL)
-        info.loc = location;
-    free(location);
-
-    char *callsite = get_callsite(1);
-    if (callsite != NULL)
-        info.callsite = callsite;
-    free(callsite);
+    info.definition_location = get_definition_location_cpp(op);
+    info.callsite_location = get_callsite_cpp(1);
 
     if (ns) {
         info.name = string(ns) + "::" + CHKSTR(name);
@@ -159,15 +151,8 @@ closure_info_t function_exit_get_info(dyntrace_context_t *context,
     info.call_id = get<0>(elem);
     info.fn_type = function_type::CLOSURE;
 
-    char *location = get_location(op);
-    if (location != NULL)
-        info.loc = location;
-    free(location);
-
-    char *callsite = get_callsite(0);
-    if (callsite != NULL)
-        info.callsite = callsite;
-    free(callsite);
+    info.definition_location = get_definition_location_cpp(op);
+    info.callsite_location = get_callsite_cpp(0);
 
     if (ns) {
         info.name = string(ns) + "::" + CHKSTR(name);
@@ -212,16 +197,8 @@ builtin_info_t builtin_entry_get_info(dyntrace_context_t *context,
     call_stack_elem_t elem = (tracer_state(context).fun_stack.back());
     info.parent_call_id = get<0>(elem);
 
-    char *location = get_location(op);
-    if (location != NULL) {
-        info.loc = location;
-    }
-    free(location);
-
-    char *callsite = get_callsite(0);
-    if (callsite != NULL)
-        info.callsite = callsite;
-    free(callsite);
+    info.definition_location = get_definition_location_cpp(op);
+    info.callsite_location = get_callsite_cpp(0);
 
     info.call_ptr = get_sexp_address(rho);
     info.call_id = make_funcall_id(context, op);
@@ -267,15 +244,8 @@ builtin_info_t builtin_exit_get_info(dyntrace_context_t *context,
     info.parent_call_id = get<0>(parent_elem);
     info.recursion = is_recursive(context, info.fn_id);
 
-    char *location = get_location(op);
-    if (location != NULL)
-        info.loc = location;
-    free(location);
-
-    char *callsite = get_callsite(0);
-    if (callsite != NULL)
-        info.callsite = callsite;
-    free(callsite);
+    info.definition_location = get_definition_location_cpp(op);
+    info.callsite_location = get_callsite_cpp(0);
 
     tracer_state(context).full_stack.pop_back();
     get_stack_parent(info, tracer_state(context).full_stack);

--- a/src/sexptypes.cpp
+++ b/src/sexptypes.cpp
@@ -82,101 +82,53 @@ void get_full_type_inner(SEXP sexp, SEXP rho, full_sexp_type &result,
         return;
     }
 
-    // Question... are all BCODEs functions?
     if (type == sexp_type::BCODE) {
         infer_type_from_bytecode(sexp, rho, result, visited);
-        //            bool try_to_attach_symbol_value = (rho != R_NilValue) ?
-        //            isEnvironment(rho) : false;
-        //            if (!try_to_attach_symbol_value) return;
-        //
-        //            SEXP uncompiled_sexp = BODY_EXPR(sexp);
-        //            SEXP underlying_expression =
-        //            findVar(PRCODE(uncompiled_sexp),
-        //            rho);
-        //
-        //            if (underlying_expression == R_UnboundValue) return;
-        //            if (underlying_expression == R_MissingArg) return;
-        //
-        //            PROTECT(underlying_expression);
-        //            //get_full_type(underlying_expression, rho, result,
-        //            visited);
-        //           UNPROTECT(1);
-
-        // Rprintf("hi from dbg\n`");
         return;
     }
 
     if (type == sexp_type::SYM) {
         bool try_to_attach_symbol_value =
-            (rho != R_NilValue) ? isEnvironment(rho) : false;
+                (rho != R_NilValue) ? isEnvironment(rho) : false;
         if (!try_to_attach_symbol_value)
             return;
-        /* FIXME - findVar can eval an expression. This can fire another hook,
-           leading to spurious data.
-                   Reproduced below is a gdb backtrace obtained by running
-           `dplyr`.
-                   At #7, get_full_type_inner invokes `findVar` which leads to
-           `eval` on #2.
 
-           0x00000000004d4b3e in R_execClosure (call=0x94e1db0,
-           newrho=0x94e1ec8,
-           sysparent=0x1a05f80,
-           rho=0x1a05f80, arglist=0x19d6b68, op=0x9534cb0) at eval.c:1612
-           1612	    RDT_HOOK(probe_function_entry, call, op, newrho);
-           (gdb) bt
-           #0  0x00000000004d4b3e in R_execClosure (call=0x94e1db0,
-           newrho=0x94e1ec8, sysparent=0x1a05f80,
-           rho=0x1a05f80, arglist=0x19d6b68, op=0x9534cb0) at eval.c:1612
-           #1  0x00000000004d49e9 in Rf_applyClosure (call=0x94e1db0,
-           op=0x9534cb0,
-           arglist=0x19d6b68,
-           rho=0x1a05f80, suppliedvars=0x19d6b68) at eval.c:1583
-           #2  0x00000000004d2db7 in Rf_eval (e=0x94e1db0, rho=0x1a05f80) at
-           eval.c:776
-           #3  0x00000000004bf6c9 in getActiveValue (fun=0x9534cb0) at
-           envir.c:154
-           #4  0x00000000004bfa53 in R_HashGet (hashcode=0, symbol=0x54de8f8,
-           table=0x1e3a4328) at envir.c:281
-           #5  0x00000000004c1781 in Rf_findVarInFrame3 (rho=0x953dd50,
-           symbol=0x54de8f8, doGet=TRUE)
-           at envir.c:1042
-           #6  0x00000000004c1fb1 in Rf_findVar (symbol=0x54de8f8,
-           rho=0x953dd50) at
-           envir.c:1221
-           #7  0x00007f3bcb98893a in
-           recorder_t<psql_recorder_t>::get_full_type_inner (
-           this=0x7f3bcbbde159 <trace_promises<psql_recorder_t>::rec_impl>,
-           sexp=0x54de8f8, rho=0x9520500,
-           result=std::vector of length 1, capacity 1 = {...}, visited=std::set
-           with
-           1 elements = {...})
-           at
-           /home/aviral/projects/aviral-r-dyntrace/rdt-plugins/promises/src/recorder.h:332
-           #8  0x00007f3bcb98542f in recorder_t<psql_recorder_t>::get_full_type
-           (
-           this=0x7f3bcbbde159 <trace_promises<psql_recorder_t>::rec_impl>,
-           promise=0x94e1d78, rho=0x9520500,
-           result=std::vector of length 1, capacity 1 = {...})
-           at
-           /home/aviral/projects/aviral-r-dyntrace/rdt-plugins/promises/src/recorder.h:289
-           #9  0x00007f3bcb980aeb in
-           recorder_t<psql_recorder_t>::create_promise_get_info (
-           this=0x7f3bcbbde159 <trace_promises<psql_recorder_t>::rec_impl>,
-           promise=0x94e1d78, rho=0x9520500)
-           at
-           /home/aviral/projects/aviral-r-dyntrace/rdt-plugins/promises/src/recorder.h:352
-         */
-        SEXP symbol_points_to = find_promise_in_environment(sexp, rho);
+        lookup_result r = find_binding_in_environment(sexp, rho);
 
-        if (symbol_points_to == R_UnboundValue)
-            return;
-        if (symbol_points_to == R_MissingArg)
-            return;
-        // if (TYPEOF(symbol_points_to) == SYMSXP) return;
+        switch (r.status) {
+            case lookup_status::SUCCESS: {
+                SEXP symbol_points_to = r.value;
+                if (symbol_points_to == R_UnboundValue
+                    || symbol_points_to == R_MissingArg)
+                    return;
 
-        get_full_type_inner(symbol_points_to, rho, result, visited);
+                get_full_type_inner(symbol_points_to, rho, result, visited);
 
-        return;
+                return;
+            }
+
+            case lookup_status::SUCCESS_ACTIVE_BINDING: {
+                result.push_back(sexp_type::ACTIVE_BINDING);
+
+                SEXP symbol_points_to = r.value;
+                if (symbol_points_to == R_UnboundValue
+                    || symbol_points_to == R_MissingArg)
+                    return;
+
+                /* TODO in order to proceed to explore active bindings,
+                   we'd need the environment in which it's defined */
+                // get_full_type_inner(symbol_points_to, rho, result, visited);
+                result.push_back(static_cast<sexp_type>(TYPEOF(r.value)));
+                return;
+            }
+
+            default: {
+                string msg = lookup_status_to_string(r.status);
+                dyntrace_log_warning("%s", msg.c_str());
+                result.push_back(sexp_type::OMEGA);
+                return;
+            }
+        }
     }
 }
 

--- a/src/sexptypes.h
+++ b/src/sexptypes.h
@@ -134,33 +134,35 @@ enum {
 };
 
 enum class sexp_type {
+  // Canonical
   NIL = 0,
-    SYM = 1,
-    LIST = 2,
-    CLOS = 3,
-    ENV = 4,
-    PROM = 5,
-    LANG = 6,
-    SPECIAL = 7,
-    BUILTIN = 8,
-    CHAR = 9,
-    LGL = 10,
-    INT = 13,
-    REAL = 14,
-    CPLX = 15,
-    STR = 16,
-    DOT = 17,
-    ANY = 18,
-    VEC = 19,
-    EXPR = 20,
-    BCODE = 21,
-    EXTPTR = 22,
-    WEAKREF = 23,
-    RAW = 24,
-    S4 = 25,
+  SYM = 1,
+  LIST = 2,
+  CLOS = 3,
+  ENV = 4,
+  PROM = 5,
+  LANG = 6,
+  SPECIAL = 7,
+  BUILTIN = 8,
+  CHAR = 9,
+  LGL = 10,
+  INT = 13,
+  REAL = 14,
+  CPLX = 15,
+  STR = 16,
+  DOT = 17,
+  ANY = 18,
+  VEC = 19,
+  EXPR = 20,
+  BCODE = 21,
+  EXTPTR = 22,
+  WEAKREF = 23,
+  RAW = 24,
+  S4 = 25,
 
   // I made these up:
-    OMEGA = 69
+  OMEGA = 69,
+  ACTIVE_BINDING = 42
 };
 
 typedef std::vector<sexp_type> full_sexp_type;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -116,9 +116,16 @@ static const char *get_filename(SEXP srcref) {
             srcref = VECTOR_ELT(srcref, 0);
         SEXP srcfile = getAttrib(srcref, R_SrcfileSymbol);
         if (TYPEOF(srcfile) == ENVSXP) {
-            SEXP filename = find_promise_in_environment(install("filename"), srcfile);
-            if (isString(filename) && Rf_length(filename)) {
-                return CHAR(STRING_ELT(filename, 0));
+            lookup_result r = find_binding_in_environment(install("filename"), srcfile); // TODO we should move install("filename") to be executed only once
+            if (r.status == lookup_status::SUCCESS) {
+                SEXP filename = r.value;
+                if (isString(filename) && Rf_length(filename)) {
+                    return CHAR(STRING_ELT(filename, 0));
+                }
+            } else {
+                // Not sure what the frequency of this is. Making it an error for now, and we'll see what happens.
+                string msg = lookup_status_to_string(r.status);
+                dyntrace_log_error("%s", msg.c_str());
             }
         }
     }
@@ -126,40 +133,29 @@ static const char *get_filename(SEXP srcref) {
     return NULL;
 }
 
-char *get_callsite(int how_far_in_the_past) {
-    SEXP srcref = R_GetCurrentSrcref(how_far_in_the_past);
+inline string extract_location_information(SEXP srcref) {
     const char *filename = get_filename(srcref);
     int lineno = get_lineno(srcref);
     int colno = get_colno(srcref);
-    char *location = NULL;
 
     if (filename) {
-        if (strlen(filename) > 0) {
-            asprintf(&location, "%s:%d,%d", filename, lineno, colno);
-        } else {
-            asprintf(&location, "<console>:%d,%d", lineno, colno);
-        }
-    }
-
-    return location;
+        stringstream result;
+        result << ((strlen(filename) > 0) ? filename : "<console>")
+               << ":" << std::to_string(lineno)
+               << "," << std::to_string(colno);
+        return result.str();
+    } else
+        return "";
 }
 
-char *get_location(SEXP op) {
+string get_callsite_cpp(int how_far_in_the_past) {
+    SEXP srcref = R_GetCurrentSrcref(how_far_in_the_past);
+    return extract_location_information(srcref);
+}
+
+string get_definition_location_cpp(SEXP op) {
     SEXP srcref = getAttrib(op, R_SrcrefSymbol);
-    const char *filename = get_filename(srcref);
-    int lineno = get_lineno(srcref);
-    int colno = get_colno(srcref);
-    char *location = NULL;
-
-    if (filename) {
-        if (strlen(filename) > 0) {
-            asprintf(&location, "%s:%d,%d", filename, lineno, colno);
-        } else {
-            asprintf(&location, "<console>:%d,%d", lineno, colno);
-        }
-    }
-
-    return location;
+    return extract_location_information(srcref);
 }
 
 const char *get_call(SEXP call) {

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -29,8 +29,8 @@ std::underlying_type_t<T> to_underlying_type(const T &enum_val) {
 std::string compute_hash(const char *data);
 const char *get_ns_name(SEXP op);
 const char *get_name(SEXP call);
-char *get_location(SEXP op);
-char *get_callsite(int);
+std::string get_definition_location_cpp(SEXP op);
+std::string get_callsite_cpp(int);
 const char *get_call(SEXP call);
 int is_byte_compiled(SEXP op);
 // char *to_string(SEXP var);


### PR DESCRIPTION
Lookup covers active binding and has proper error reporting. There are also some minor nit-picks for some of the code.

Summary of runnign selected packages:
fixes #24 ForecastFramework NO ERRORS
fixes #23 janitor NO ERRORS
fixes #22 cleanEHR UNRELATED ERROR (unbalanced stack, unknown)
fixes #21 alluvial NO ERRORS
fixes #20 DeLorean UNRELATED ERROR (object 'fit' not found)
fixes #19 covmat UNRELATED ERROR (file ont found)
fixes #18 carpenter NO ERRORS
fixes #17 heemod UNRELATED ERROR (unbalanced stack, unknown)
fixes #16 KraljicMatrix NO ERRORS
fixes #15 polypoly NO ERRORS
fixes #14 nonmemica UNRELATED ERROR (missing package)
fixes #13 queuecomputer NO ERRORS
fixes #12 tidytext UNRELATED ERROR (unkonwn package)
fixes #11 shazam UNRELATED ERROR (cannot infer type of opcode : 7)