### PR TITLE
Add code that creates OK files on successful tracing

### DIFF
--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -4,12 +4,14 @@
 SqlSerializer::SqlSerializer(const std::string &database_filepath,
                              const std::string &schema_filepath, bool truncate,
                              bool verbose)
-    : verbose(verbose), indentation(0) {
+    : verbose(verbose), indentation(0), database_filepath(database_filepath) {
     open_database(database_filepath, truncate);
     open_trace(database_filepath, truncate);
     create_tables(schema_filepath);
     prepare_statements();
 }
+
+std::string SqlSerializer::get_database_filepath() const { return database_filepath; }
 
 void SqlSerializer::open_database(const std::string database_path,
                                   bool truncate) {

--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -12,6 +12,7 @@ class SqlSerializer {
                   const std::string &schema_path, bool truncate = false,
                   bool verbose = false);
     ~SqlSerializer();
+    std::string get_database_filepath() const;
     void serialize_start_trace();
     void serialize_finish_trace();
     void serialize_function_entry(dyntrace_context_t *context,
@@ -76,6 +77,7 @@ class SqlSerializer {
     sqlite3_stmt *populate_insert_argument_statement(const closure_info_t &info,
                                                      int index);
 
+    std::string database_filepath;
     bool verbose;
     int indentation;
     sqlite3 *database = NULL;

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -119,6 +119,17 @@ void end(dyntrace_context_t *context) {
                              tracer_state(context).full_stack.size());
         tracer_state(context).full_stack.clear();
     }
+
+    // create a file if the execution is normal.
+    // end function is only called if the execution is normal,
+    // so this file will only be created if everything goes fine.
+    std::string database_filepath = tracer_serializer(context).get_database_filepath();
+    size_t lastindex = database_filepath.find_last_of(".");
+    std::string ok_filepath = database_filepath.substr(0, lastindex) + ".OK";
+    std::ofstream ok_file(ok_filepath);
+    ok_file << "NORMAL EXIT";
+    ok_file.close();
+
 }
 
 // Triggered when entering function evaluation.


### PR DESCRIPTION
If the tracing is successful, a ".OK" file is created
to identify databases which are safe for analysis.
Earlier, this file was being generated externally by
the instrumented vignette. However, that would always
create a .OK file, even if the tracer was unsuccessful
in tracing the vignette. This commit adds code to the
tracer to create this file in the `end` function. This
function only gets called if the tracing is successful.