### PR TITLE
Add tracing for formal parameter position of arguments

### DIFF
--- a/exec/schema.sql
+++ b/exec/schema.sql
@@ -29,6 +29,7 @@ create table if not exists arguments (
     --[ data ]-----------------------------------------------------------------
     name text not null,
     position integer not null,
+    formal_parameter_position integer not null,
     --[ relations ]------------------------------------------------------------
     call_id integer not null,
     --[ keys ]-----------------------------------------------------------------

--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -11,7 +11,9 @@ SqlSerializer::SqlSerializer(const std::string &database_filepath,
     prepare_statements();
 }
 
-std::string SqlSerializer::get_database_filepath() const { return database_filepath; }
+std::string SqlSerializer::get_database_filepath() const {
+    return database_filepath;
+}
 
 void SqlSerializer::open_database(const std::string database_path,
                                   bool truncate) {
@@ -120,7 +122,7 @@ void SqlSerializer::prepare_statements() {
         compile("insert into calls values (?,?,?,?,?,?,?,?,?);");
 
     insert_argument_statement =
-        compile("insert into arguments values (?,?,?,?);");
+        compile("insert into arguments values (?,?,?,?,?);");
 
     insert_promise_statement =
         compile("insert into promises values (?,?,?,?,?,?,?);");
@@ -465,8 +467,8 @@ sqlite3_stmt *SqlSerializer::populate_call_statement(const call_info_t &info) {
     if (info.callsite_location.empty())
         sqlite3_bind_null(insert_call_statement, 3);
     else
-        sqlite3_bind_text(insert_call_statement, 3, info.callsite_location.c_str(), -1,
-                          SQLITE_TRANSIENT);
+        sqlite3_bind_text(insert_call_statement, 3,
+                          info.callsite_location.c_str(), -1, SQLITE_TRANSIENT);
 
     sqlite3_bind_int(insert_call_statement, 4, info.fn_compiled ? 1 : 0);
     sqlite3_bind_text(insert_call_statement, 5, info.fn_id.c_str(),
@@ -535,7 +537,8 @@ SqlSerializer::populate_function_statement(const call_info_t &info) {
     if (info.definition_location.empty())
         sqlite3_bind_null(insert_function_statement, 2);
     else
-        sqlite3_bind_text(insert_function_statement, 2, info.definition_location.c_str(), -1,
+        sqlite3_bind_text(insert_function_statement, 2,
+                          info.definition_location.c_str(), -1,
                           SQLITE_TRANSIENT);
 
     if (info.fn_definition.empty())
@@ -552,15 +555,17 @@ SqlSerializer::populate_function_statement(const call_info_t &info) {
     return insert_function_statement;
 }
 
-sqlite3_stmt *
-SqlSerializer::populate_insert_argument_statement(const closure_info_t &info,
-                                                  int index) {
-    const arg_t &argument = info.arguments.all()[index].get();
+sqlite3_stmt *SqlSerializer::populate_insert_argument_statement(
+    const closure_info_t &info, int actual_parameter_position) {
+    const arg_t &argument =
+        info.arguments.all()[actual_parameter_position].get();
     sqlite3_bind_int(insert_argument_statement, 1, get<1>(argument));
     sqlite3_bind_text(insert_argument_statement, 2, get<0>(argument).c_str(),
                       -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(insert_argument_statement, 3,
-                     index); // FIXME broken or unnecessary (pick one)
-    sqlite3_bind_int(insert_argument_statement, 4, info.call_id);
+    sqlite3_bind_int(
+        insert_argument_statement, 3,
+        actual_parameter_position); // FIXME broken or unnecessary (pick one)
+    sqlite3_bind_int(insert_argument_statement, 4, get<4>(argument));
+    sqlite3_bind_int(insert_argument_statement, 5, info.call_id);
     return insert_argument_statement;
 }

--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -75,7 +75,7 @@ class SqlSerializer {
     sqlite3_stmt *populate_function_statement(const call_info_t &info);
 
     sqlite3_stmt *populate_insert_argument_statement(const closure_info_t &info,
-                                                     int index);
+                                                     int actual_parameter_position);
 
     std::string database_filepath;
     bool verbose;

--- a/src/State.h
+++ b/src/State.h
@@ -35,8 +35,8 @@ typedef pair<call_id_t, string> arg_key_t;
 
 rid_t get_sexp_address(SEXP e);
 
-typedef tuple<string, arg_id_t, prom_id_t, bool> arg_t;
-typedef tuple<arg_id_t, prom_id_t, bool> anon_arg_t;
+typedef tuple<string, arg_id_t, prom_id_t, bool, int> arg_t;
+typedef tuple<arg_id_t, prom_id_t, bool, int> anon_arg_t;
 
 enum class function_type {
     CLOSURE = 0,

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -167,9 +167,11 @@ arg_id_t get_argument_id(dyntrace_context_t *context, call_id_t call_id,
 arglist_t get_arguments(dyntrace_context_t *context, call_id_t  call_id, SEXP op,
                         SEXP rho) {
     arglist_t arguments;
-
-    for (SEXP formals = FORMALS(op); formals != R_NilValue;
-         formals = CDR(formals)) {
+    int formal_parameter_position;
+    SEXP formals;
+    for (formal_parameter_position = 0, formals = FORMALS(op);
+         formals != R_NilValue;
+         formals = CDR(formals), formal_parameter_position++) {
         // Retrieve the argument name.
         SEXP argument_expression = TAG(formals);
         SEXP promise_expression = R_NilValue;
@@ -205,7 +207,7 @@ arglist_t get_arguments(dyntrace_context_t *context, call_id_t  call_id, SEXP op
                     arguments.push_back(std::make_tuple(
                         get_argument_id(context, call_id, to_string(i++)),
                         get_promise_id(context, ddd_promise_expression),
-                        default_argument)); // ...
+                        default_argument, formal_parameter_position)); // ...
                                             // argument
                                             // without a
                                             // name
@@ -216,7 +218,7 @@ arglist_t get_arguments(dyntrace_context_t *context, call_id_t  call_id, SEXP op
                             ddd_arg_name,
                             get_argument_id(context, call_id, ddd_arg_name),
                             get_promise_id(context, ddd_promise_expression),
-                            default_argument),
+                            default_argument, formal_parameter_position),
                         true); // this flag says we're inserting a ... argument
                 }
             }
@@ -230,7 +232,7 @@ arglist_t get_arguments(dyntrace_context_t *context, call_id_t  call_id, SEXP op
 
             arguments.push_back(std::make_tuple(
                 arg_name, get_argument_id(context, call_id, arg_name),
-                prom_id, default_argument));
+                prom_id, default_argument, formal_parameter_position));
         }
     }
 

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -101,12 +101,12 @@ void serialize_execution_time(dyntrace_context_t *context) {
 
 void end(dyntrace_context_t *context) {
     tracer_state(context).finish_pass();
-        serialize_execution_time(context);
-        // serialize_execution_count(context);
-        tracer_serializer(context).serialize_finish_trace();
-        tracer_serializer(context).serialize_metadatum(
-            "DYNTRACE_END_DATETIME",
-            remove_null(context->dyntracing_context->end_datetime));
+    serialize_execution_time(context);
+    // serialize_execution_count(context);
+    tracer_serializer(context).serialize_finish_trace();
+    tracer_serializer(context).serialize_metadatum(
+        "DYNTRACE_END_DATETIME",
+        remove_null(context->dyntracing_context->end_datetime));
 
     if (!tracer_state(context).fun_stack.empty()) {
         dyntrace_log_warning("Function stack is not balanced: %d remaining",
@@ -115,21 +115,22 @@ void end(dyntrace_context_t *context) {
     }
 
     if (!tracer_state(context).full_stack.empty()) {
-        dyntrace_log_warning("Function/promise stack is not balanced: %d remaining",
-                             tracer_state(context).full_stack.size());
+        dyntrace_log_warning(
+            "Function/promise stack is not balanced: %d remaining",
+            tracer_state(context).full_stack.size());
         tracer_state(context).full_stack.clear();
     }
 
     // create a file if the execution is normal.
     // end function is only called if the execution is normal,
     // so this file will only be created if everything goes fine.
-    std::string database_filepath = tracer_serializer(context).get_database_filepath();
+    std::string database_filepath =
+        tracer_serializer(context).get_database_filepath();
     size_t lastindex = database_filepath.find_last_of(".");
     std::string ok_filepath = database_filepath.substr(0, lastindex) + ".OK";
     std::ofstream ok_file(ok_filepath);
     ok_file << "NORMAL EXIT";
     ok_file.close();
-
 }
 
 // Triggered when entering function evaluation.


### PR DESCRIPTION
This commit adds support to trace the formal parameter
position of arguments along with their actual position.
This information is useful for certain analyses which
rely not on the actual argument position (which can
vary due to ...) but on the formal parameter position.