### PR TITLE
Add serialization of return value type of function calls

### DIFF
--- a/exec/schema.sql
+++ b/exec/schema.sql
@@ -55,6 +55,15 @@ create table if not exists calls (
     foreign key (parent_id) references calls
 );
 
+create table if not exists call_returns (
+    --[ relations ]------------------------------------------------------------
+    call_id integer not null,
+    --[ data ]-----------------------------------------------------------------
+    return_value_type integer not null,
+    --[ keys ]-----------------------------------------------------------------
+    foreign key (call_id) references calls
+);
+
 create table if not exists promises (
     --[ identity ]-------------------------------------------------------------
     id integer primary key, -- equal to promise pointer SEXP

--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -121,6 +121,9 @@ void SqlSerializer::prepare_statements() {
     insert_call_statement =
         compile("insert into calls values (?,?,?,?,?,?,?,?,?);");
 
+    insert_call_return_statement =
+        compile("insert into call_returns values (?,?);");
+
     insert_argument_statement =
         compile("insert into arguments values (?,?,?,?,?);");
 
@@ -327,6 +330,7 @@ void SqlSerializer::serialize_function_entry(dyntrace_context_t *context,
 
 void SqlSerializer::serialize_function_exit(const closure_info_t &info) {
     unindent();
+    execute(populate_call_return_statement(info));
 }
 
 void SqlSerializer::serialize_builtin_entry(dyntrace_context_t *context,
@@ -343,6 +347,7 @@ void SqlSerializer::serialize_builtin_entry(dyntrace_context_t *context,
 
 void SqlSerializer::serialize_builtin_exit(const builtin_info_t &info) {
     unindent();
+    execute(populate_call_return_statement(info));
 }
 
 void SqlSerializer::serialize_force_promise_entry(dyntrace_context_t *context,
@@ -493,6 +498,14 @@ sqlite3_stmt *SqlSerializer::populate_call_statement(const call_info_t &info) {
     }
 
     return insert_call_statement;
+}
+
+sqlite3_stmt *
+SqlSerializer::populate_call_return_statement(const call_info_t &info) {
+    sqlite3_bind_int(insert_call_return_statement, 1, (int)info.call_id);
+    sqlite3_bind_int(insert_call_return_statement, 2,
+                     (int)info.return_value_type);
+    return insert_call_return_statement;
 }
 
 sqlite3_stmt *SqlSerializer::populate_promise_association_statement(

--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -63,6 +63,8 @@ class SqlSerializer {
 
     sqlite3_stmt *populate_call_statement(const call_info_t &info);
 
+    sqlite3_stmt *populate_call_return_statement(const call_info_t &info);
+
     sqlite3_stmt *
     populate_insert_promise_statement(const prom_basic_info_t &info);
 
@@ -74,8 +76,9 @@ class SqlSerializer {
                                               const string value);
     sqlite3_stmt *populate_function_statement(const call_info_t &info);
 
-    sqlite3_stmt *populate_insert_argument_statement(const closure_info_t &info,
-                                                     int actual_parameter_position);
+    sqlite3_stmt *
+    populate_insert_argument_statement(const closure_info_t &info,
+                                       int actual_parameter_position);
 
     std::string database_filepath;
     bool verbose;
@@ -86,6 +89,7 @@ class SqlSerializer {
     sqlite3_stmt *insert_function_statement = NULL;
     sqlite3_stmt *insert_argument_statement = NULL;
     sqlite3_stmt *insert_call_statement = NULL;
+    sqlite3_stmt *insert_call_return_statement = NULL;
     sqlite3_stmt *insert_promise_statement = NULL;
     sqlite3_stmt *insert_promise_association_statement = NULL;
     sqlite3_stmt *insert_promise_evaluation_statement = NULL;

--- a/src/State.h
+++ b/src/State.h
@@ -1,8 +1,8 @@
 #ifndef __STATE_H__
 #define __STATE_H__
 
-#include "stdlibs.h"
 #include "sexptypes.h"
+#include "stdlibs.h"
 
 using namespace std;
 
@@ -107,6 +107,7 @@ struct call_info_t {
     recursion_type recursion; // TODO unnecessary?
 
     stack_event_t parent_on_stack;
+    sexp_type return_value_type;
 };
 
 class arglist_t {
@@ -273,7 +274,6 @@ prom_id_t get_parent_promise(dyntrace_context_t *context);
 arg_id_t get_argument_id(dyntrace_context_t *context, call_id_t call_id,
                          const string &argument);
 arglist_t get_arguments(dyntrace_context_t *, call_id_t, SEXP op, SEXP rho);
-
 
 size_t get_no_of_ancestor_promises_on_stack(dyntrace_context_t *context);
 size_t get_no_of_ancestors_on_stack();

--- a/src/probes.h
+++ b/src/probes.h
@@ -20,7 +20,8 @@ void builtin_entry(dyntrace_context_t *context, const SEXP call, const SEXP op,
 void specialsxp_entry(dyntrace_context_t *context, const SEXP call,
                       const SEXP op, const SEXP rho);
 void print_exit_info(dyntrace_context_t *context, const SEXP call,
-                     const SEXP op, const SEXP rho, function_type fn_type);
+                     const SEXP op, const SEXP rho, function_type fn_type,
+                     const SEXP retval);
 void builtin_exit(dyntrace_context_t *context, const SEXP call, const SEXP op,
                   const SEXP rho, const SEXP retval);
 void specialsxp_exit(dyntrace_context_t *context, const SEXP call,

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -3,21 +3,22 @@
 
 #include "Context.h"
 #include "State.h"
-#include "utilities.h"
 #include "sexptypes.h"
+#include "utilities.h"
 
 closure_info_t function_entry_get_info(dyntrace_context_t *context,
                                        const SEXP call, const SEXP op,
                                        const SEXP rho);
 closure_info_t function_exit_get_info(dyntrace_context_t *context,
                                       const SEXP call, const SEXP op,
-                                      const SEXP rho);
+                                      const SEXP rho, const SEXP retval);
 builtin_info_t builtin_entry_get_info(dyntrace_context_t *context,
                                       const SEXP call, const SEXP op,
                                       const SEXP rho, function_type fn_type);
 builtin_info_t builtin_exit_get_info(dyntrace_context_t *context,
                                      const SEXP call, const SEXP op,
-                                     const SEXP rho, function_type fn_type);
+                                     const SEXP rho, function_type fn_type,
+                                     const SEXP retval);
 prom_basic_info_t create_promise_get_info(dyntrace_context_t *context,
                                           const SEXP promise, const SEXP rho);
 prom_info_t force_promise_entry_get_info(dyntrace_context_t *context,


### PR DESCRIPTION
This commit adds a new table to the database which relates
the type of the return value of each function call with the
call id. This information is required by some analyses, for
e.g. to find out functions that return environments. These
functions can potentially be involved in implementing lazy
data structures.