### PR TITLE
Add support for counting function calls between events

### DIFF
--- a/exec/schema.sql
+++ b/exec/schema.sql
@@ -127,8 +127,11 @@ create table if not exists promise_lifecycle (
     --[ relation ]-------------------------------------------------------------
     promise_id integer not null,
     --[ data ]-----------------------------------------------------------------
-    event_type integer not null, --- 0x0: creation, -- 0x1: lookup -- 0x2: unmark
+    event_type integer not null, --- 0: creation, -- 1: lookup/force -- 2: unmark --3: expression lookup
     gc_trigger_counter integer not null,
+    builtin_counter integer not null,
+    special_counter integer not null,
+    closure_counter integer not null,
     --[ keys ]-----------------------------------------------------------------
     foreign key (promise_id) references promises,
     foreign key (gc_trigger_counter) references gc_trigger
@@ -147,7 +150,10 @@ create table if not exists gc_trigger (
     counter integer primary key,
     --[ data ]-----------------------------------------------------------------
     ncells real not null,
-    vcells real not null
+    vcells real not null,
+    builtin_calls integer not null,
+    special_calls integer not null,
+    closure_calls integer not null
 );
 
 create table if not exists type_distribution (

--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -141,13 +141,13 @@ void SqlSerializer::prepare_statements() {
         compile("insert into promise_returns values (?,?,?);");
 
     insert_promise_lifecycle_statement =
-        compile("insert into promise_lifecycle values (?,?,?);");
+        compile("insert into promise_lifecycle values (?,?,?,?,?,?);");
 
     insert_promise_argument_type_statement =
         compile("insert into promise_argument_types values (?,?);");
 
     insert_gc_trigger_statement =
-        compile("insert into gc_trigger values (?,?,?);");
+        compile("insert into gc_trigger values (?,?,?,?,?,?);");
 
     insert_type_distribution_statement =
         compile("insert into type_distribution values (?,?,?,?);");
@@ -231,11 +231,19 @@ void SqlSerializer::execute(sqlite3_stmt *statement) {
     sqlite3_reset(statement);
 }
 
-void SqlSerializer::serialize_promise_lifecycle(const prom_gc_info_t &info) {
+void SqlSerializer::serialize_promise_lifecycle(
+    const prom_lifecycle_info_t &info) {
     sqlite3_bind_int(insert_promise_lifecycle_statement, 1, info.promise_id);
     sqlite3_bind_int(insert_promise_lifecycle_statement, 2, info.event);
     sqlite3_bind_int(insert_promise_lifecycle_statement, 3,
                      info.gc_trigger_counter);
+    sqlite3_bind_int(insert_promise_lifecycle_statement, 4,
+                     info.builtin_counter);
+    sqlite3_bind_int(insert_promise_lifecycle_statement, 5,
+                     info.special_counter);
+    sqlite3_bind_int(insert_promise_lifecycle_statement, 6,
+                     info.closure_counter);
+
     execute(insert_promise_lifecycle_statement);
 }
 
@@ -243,6 +251,9 @@ void SqlSerializer::serialize_gc_exit(const gc_info_t &info) {
     sqlite3_bind_int(insert_gc_trigger_statement, 1, info.counter);
     sqlite3_bind_double(insert_gc_trigger_statement, 2, info.ncells);
     sqlite3_bind_double(insert_gc_trigger_statement, 3, info.vcells);
+    sqlite3_bind_int(insert_gc_trigger_statement, 4, info.builtin_calls);
+    sqlite3_bind_int(insert_gc_trigger_statement, 5, info.special_calls);
+    sqlite3_bind_int(insert_gc_trigger_statement, 6, info.closure_calls);
     execute(insert_gc_trigger_statement);
 }
 

--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -29,7 +29,7 @@ class SqlSerializer {
     void serialize_promise_lookup(const prom_info_t &info, int clock_id);
     void serialize_promise_expression_lookup(const prom_info_t &info,
                                              int clock_id);
-    void serialize_promise_lifecycle(const prom_gc_info_t &info);
+    void serialize_promise_lifecycle(const prom_lifecycle_info_t &info);
     void serialize_promise_argument_type(const prom_id_t prom_id,
                                          bool default_argument);
     void serialize_vector_alloc(const type_gc_info_t &info);

--- a/src/State.h
+++ b/src/State.h
@@ -213,12 +213,18 @@ struct gc_info_t {
     int counter;
     double ncells;
     double vcells;
+    int builtin_calls;
+    int special_calls;
+    int closure_calls;
 };
 
-struct prom_gc_info_t {
+struct prom_lifecycle_info_t {
     prom_id_t promise_id;
     event_t event;
     int gc_trigger_counter;
+    int builtin_counter;
+    int special_counter;
+    int closure_counter;
 };
 
 struct type_gc_info_t {
@@ -331,6 +337,10 @@ struct tracer_state_t {
                                            // (unless overwrite is true)
     int gc_trigger_counter; // Incremented each time there is a gc_entry
 
+    int builtin_counter;       // Increment each time a builtin is called
+    int special_counter;       // Increment each time a special is called
+    int closure_counter;       // Increment each time a closure is called
+
     unordered_map<SEXP, std::pair<env_id_t, unordered_map<string, var_id_t>>>
         environments;
     void start_pass(dyntrace_context_t *context, const SEXP prom);
@@ -344,6 +354,21 @@ struct tracer_state_t {
     env_id_t to_environment_id(SEXP rho);
     var_id_t to_variable_id(SEXP symbol, SEXP rho, bool &exists);
     prom_id_t enclosing_promise_id();
+
+    void increment_closure_counter();
+    void increment_special_counter();
+    void increment_builtin_counter();
+    void increment_gc_trigger_counter();
+
+    int get_closure_counter() const;
+    int get_special_counter() const;
+    int get_builtin_counter() const;
+    int get_gc_trigger_counter() const;
+
+    int get_closure_calls();
+    int get_special_calls();
+    int get_builtin_calls();
+
     tracer_state_t();
 };
 #endif /* __STATE_H__ */

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -255,14 +255,6 @@ builtin_info_t builtin_exit_get_info(dyntrace_context_t *context,
     return info;
 }
 
-gc_info_t gc_exit_get_info(int gc_count, double vcells, double ncells) {
-    gc_info_t info;
-    info.vcells = vcells;
-    info.ncells = ncells;
-    info.counter = gc_count;
-    return info;
-}
-
 prom_basic_info_t create_promise_get_info(dyntrace_context_t *context,
                                           const SEXP promise, const SEXP rho) {
     prom_basic_info_t info;

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -29,6 +29,5 @@ prom_info_t promise_lookup_get_info(dyntrace_context_t *context,
                                     const SEXP promise);
 prom_info_t promise_expression_lookup_get_info(dyntrace_context_t *context,
                                                const SEXP prom);
-gc_info_t gc_exit_get_info(int gc_count, double vcells, double ncells);
 
 #endif /* __RECORDER_H__ */


### PR DESCRIPTION
This commit adds support to keep track of number of
functions called between consecutive GC triggers and
promise events.

This information can be used for measuring promise
related events in terms of number of function calls
instead of GC triggers.