### PR TITLE
Add promise expression id and symbol name to traces

### DIFF
--- a/exec/schema.sql
+++ b/exec/schema.sql
@@ -74,7 +74,8 @@ create table if not exists promises (
     parent_on_stack_type integer not null, -- promise = 1, call = 2, none = 0
     parent_on_stack_id integer null,
     promise_stack_depth integer not null,
-    expression text not null
+    expression text not null,
+    expression_id text not null
 );
 
 create table if not exists promise_associations (

--- a/src/SqlSerializer.cpp
+++ b/src/SqlSerializer.cpp
@@ -128,7 +128,7 @@ void SqlSerializer::prepare_statements() {
         compile("insert into arguments values (?,?,?,?,?);");
 
     insert_promise_statement =
-        compile("insert into promises values (?,?,?,?,?,?,?,?);");
+        compile("insert into promises values (?,?,?,?,?,?,?,?,?);");
 
     insert_promise_association_statement =
         compile("insert into promise_associations values (?,?,?);");
@@ -438,17 +438,22 @@ void SqlSerializer::serialize_trace(const std::string &opcode, const int id_1) {
 }
 
 void SqlSerializer::serialize_trace(const std::string &opcode, const int id_1,
+                                    const std::string id_2) {
+    trace << opcode << " " << id_1 << " " << id_2 << std::endl;
+}
+
+void SqlSerializer::serialize_trace(const std::string &opcode, const int id_1,
                                     const int id_2) {
 
     trace << opcode << " " << id_1 << " " << id_2 << std::endl;
 }
 
 void SqlSerializer::serialize_trace(const std::string &opcode, const int id_1,
-                                    const int id_2,
+                                    const int id_2, const std::string &symbol,
                                     const std::string sexptype) {
 
-    trace << opcode << " " << id_1 << " " << id_2 << " " << sexptype
-          << std::endl;
+    trace << opcode << " " << id_1 << " " << id_2 << " " << symbol << " "
+          << sexptype << std::endl;
 }
 
 void SqlSerializer::serialize_trace(const std::string &opcode,
@@ -491,6 +496,8 @@ sqlite3_stmt *SqlSerializer::populate_insert_promise_statement(
     sqlite3_bind_int(insert_promise_statement, 7, info.depth);
     sqlite3_bind_text(insert_promise_statement, 8, info.expression.c_str(), -1,
                       SQLITE_TRANSIENT);
+    sqlite3_bind_text(insert_promise_statement, 9, info.expression_id.c_str(),
+                      -1, SQLITE_TRANSIENT);
     return insert_promise_statement;
 }
 

--- a/src/SqlSerializer.h
+++ b/src/SqlSerializer.h
@@ -43,9 +43,12 @@ class SqlSerializer {
                                    const std::string &action);
     void serialize_trace(const std::string &opcode, const int id_1);
     void serialize_trace(const std::string &opcode, const int id_1,
+                         const std::string id_2);
+    void serialize_trace(const std::string &opcode, const int id_1,
                          const int id_2);
     void serialize_trace(const std::string &opcode, const int id_1,
-                         const int id_2, const std::string sexptype);
+                         const int id_2, const std::string &symbol,
+                         const std::string sexptype);
     void serialize_trace(const std::string &opcode, const fn_id_t &id_1,
                          const int id_2, const int id_3);
 

--- a/src/State.h
+++ b/src/State.h
@@ -212,6 +212,7 @@ struct prom_basic_info_t {
     stack_event_t parent_on_stack;
     int depth;
     std::string expression;
+    std::string expression_id;
 };
 
 struct prom_info_t : prom_basic_info_t {
@@ -224,7 +225,7 @@ struct prom_info_t : prom_basic_info_t {
 };
 
 struct unwind_info_t {
-    rid_t  jump_context;
+    rid_t jump_context;
     vector<call_id_t> unwound_calls;
     vector<prom_id_t> unwound_promises;
     vector<rid_t> unwound_contexts;
@@ -302,10 +303,10 @@ template <typename T>
 void get_stack_parent2(T &info, vector<stack_event_t> &stack) {
     // put the body here
     static_assert(std::is_base_of<prom_basic_info_t, T>::value ||
-                  std::is_base_of<prom_info_t, T>::value ||
-                  std::is_base_of<call_info_t, T>::value,
+                      std::is_base_of<prom_info_t, T>::value ||
+                      std::is_base_of<call_info_t, T>::value,
                   "get_stack_parent is only applicable for arguments of types: "
-                          "prom_basic_info_t,  prom_info_t, or call_info_t.");
+                  "prom_basic_info_t,  prom_info_t, or call_info_t.");
 
     if (stack.size() > 1) {
         stack_event_t stack_elem = stack.rbegin()[1];
@@ -326,8 +327,10 @@ void get_stack_parent2(T &info, vector<stack_event_t> &stack) {
     }
 }
 
-stack_event_t get_last_on_stack_by_type(vector<stack_event_t> &stack, stack_type type);
-stack_event_t get_from_back_of_stack_by_type(vector<stack_event_t> &stack, stack_type type, int rposition);
+stack_event_t get_last_on_stack_by_type(vector<stack_event_t> &stack,
+                                        stack_type type);
+stack_event_t get_from_back_of_stack_by_type(vector<stack_event_t> &stack,
+                                             stack_type type, int rposition);
 
 prom_id_t get_parent_promise(dyntrace_context_t *context);
 arg_id_t get_argument_id(dyntrace_context_t *context, call_id_t call_id,
@@ -342,7 +345,7 @@ string recursive_type_to_string(recursion_type);
 
 struct tracer_state_t {
     int clock_id; // Should be kept across Rdt calls (unless overwrite is true)
-    vector<stack_event_t> full_stack;    // Should be reset on each tracer pass
+    vector<stack_event_t> full_stack; // Should be reset on each tracer pass
 
     // Map from promise IDs to call IDs
     unordered_map<prom_id_t, call_id_t>

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -333,8 +333,8 @@ void promise_force_entry(dyntrace_context_t *context, const SEXP promise) {
 
     std::string ent_id = std::string("ent ") + std::to_string(info.prom_id);
     debug_serializer(context).serialize_interference_information(ent_id);
-    tracer_serializer(context).serialize_trace(OPCODE_PROMISE_BEGIN,
-                                               info.prom_id);
+    tracer_serializer(context).serialize_trace(
+        OPCODE_PROMISE_BEGIN, info.prom_id, info.expression_id);
     debug_serializer(context).serialize_force_promise_entry(info);
     tracer_serializer(context).serialize_force_promise_entry(
         context, info, tracer_state(context).clock_id);
@@ -571,7 +571,7 @@ void environment_action(dyntrace_context_t *context, const SEXP symbol,
     debug_serializer(context).serialize_interference_information(action_id);
     tracer_serializer(context).serialize_trace(
         action, tracer_state(context).to_environment_id(rho), variable_id,
-        sexp_type_to_string((sexp_type)TYPEOF(value)));
+        CHAR(PRINTNAME(symbol)), sexp_type_to_string((sexp_type)TYPEOF(value)));
 }
 
 void environment_define_var(dyntrace_context_t *context, const SEXP symbol,

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -249,6 +249,7 @@ prom_basic_info_t create_promise_get_info(dyntrace_context_t *context,
     dyntrace_active_dyntracer->probe_promise_expression_lookup = NULL;
     info.expression = get_expression(PRCODE(promise));
     dyntrace_active_dyntracer->probe_promise_expression_lookup = probe;
+    info.expression_id = compute_hash(info.expression.c_str());
     return info;
 }
 
@@ -269,7 +270,12 @@ prom_info_t force_promise_entry_get_info(dyntrace_context_t *context,
     get_stack_parent(info, tracer_state(context).full_stack);
     info.in_prom_id = get_parent_promise(context);
     info.depth = get_no_of_ancestor_promises_on_stack(context);
-
+    void (*probe)(dyntrace_context_t *, SEXP);
+    probe = dyntrace_active_dyntracer->probe_promise_expression_lookup;
+    dyntrace_active_dyntracer->probe_promise_expression_lookup = NULL;
+    info.expression = get_expression(PRCODE(promise));
+    dyntrace_active_dyntracer->probe_promise_expression_lookup = probe;
+    info.expression_id = compute_hash(info.expression.c_str());
     return info;
 }
 


### PR DESCRIPTION
This commit adds promise expression id and symbol name to traces.
This makes collecting results from the abstract interpreter simple
and fast. The other option would be to query the database but that
would make the already slow interference analysis, slower.